### PR TITLE
xbeam changes for sharpy branch dev_xbeam_ramp

### DIFF
--- a/src/cbeam3_interface.f90
+++ b/src/cbeam3_interface.f90
@@ -63,6 +63,7 @@ contains
         integer(c_int), intent(IN)      :: vdof(n_node)
         integer(c_int), intent(IN)      :: fdof(n_node)
 
+ 
         type(xbelem)                    :: elements(n_elem)
         type(xbnode)                    :: nodes(n_node)
         type(xbopts), intent(INOUT)     :: options
@@ -124,8 +125,8 @@ contains
                                   psi_ini,&
                                   pos_def,&
                                   psi_def,&
-                                  options&
-                                  )
+                                  options)
+                                  
         call correct_gravity_forces(n_node, n_elem, gravity_forces, psi_def, elements, nodes)
     end subroutine cbeam3_solv_nlnstatic_python
 

--- a/src/xbeam_shared.f90
+++ b/src/xbeam_shared.f90
@@ -89,6 +89,7 @@ module xbeam_shared
   real(c_double):: gravity_dir_z = 1
   logical(c_bool):: balancing = .false.
   real(c_double):: relaxation_factor = 0.3
+  logical(c_bool):: load_ramping_conv = .false.
  end type
 
 end module xbeam_shared


### PR DESCRIPTION
Updated 3 files for dev_xbeam_ramp suppport:

- cbeam3_solv.f90 -> actual algorithm update to include convergence flag, removing the nasty stop behaviour and replaced by flag to sharpy python script to drive next run with finer load steps
- xbeam_shared.f90 -> added convergence flag as one of the shared settings
- cbeam3_interface.f90 -> added support for extra parameters in the interface functions