### PR TITLE
Handle absolute threshold for convergence checks as an input option and increase default value

### DIFF
--- a/src/cbeam3_solv.f90
+++ b/src/cbeam3_solv.f90
@@ -1084,8 +1084,9 @@ DX_old = 1.0d0*options%mindelta
     mindelta = 0
     old_x = 1.0d0
     converged = .FALSE.
-    abs_threshold = epsilon(old_DX)
+    abs_threshold = options%abs_threshold
     old_DX = 1.0d0
+    ! print*, 'Last residual: ', residual
     ! Iteration loop -----------------------------------------
     do iter = 1, options%maxiterations + 1
         if (iter == options%maxiterations + 1) then

--- a/src/cbeam3_solv.f90
+++ b/src/cbeam3_solv.f90
@@ -1086,7 +1086,6 @@ DX_old = 1.0d0*options%mindelta
     converged = .FALSE.
     abs_threshold = options%abs_threshold
     old_DX = 1.0d0
-    ! print*, 'Last residual: ', residual
     ! Iteration loop -----------------------------------------
     do iter = 1, options%maxiterations + 1
         if (iter == options%maxiterations + 1) then

--- a/src/xbeam_shared.f90
+++ b/src/xbeam_shared.f90
@@ -80,7 +80,8 @@ module xbeam_shared
                                       ! =    922: cbeam3 nonlinear static + flexible-body dynamic
                                       ! =    952: cbeam3 linear flexible with nonlinear rigid-body dynamic
   real(c_double):: DeltaCurved=1d-2          ! Minimum angle for two unit vectors to be parallel.
-  real(c_double):: MinDelta=1d-8             ! Convergence parameter for Newton-Raphson iterations.
+  real(c_double):: MinDelta=1d-8             ! Relative convergence parameter for Newton-Raphson iterations.
+  real(c_double):: abs_threshold=1d-13        ! Absolute convergence parameter for Newton-Raphson iterations.
   real(c_double):: NewmarkDamp=1.d-4         ! Numerical damping in the Newmark integration scheme.
   logical(c_bool):: gravity_on = .FALSE.
   real(c_double):: gravity = 0.0d0

--- a/src/xbeam_shared.f90
+++ b/src/xbeam_shared.f90
@@ -81,7 +81,7 @@ module xbeam_shared
                                       ! =    952: cbeam3 linear flexible with nonlinear rigid-body dynamic
   real(c_double):: DeltaCurved=1d-2          ! Minimum angle for two unit vectors to be parallel.
   real(c_double):: MinDelta=1d-8             ! Relative convergence parameter for Newton-Raphson iterations.
-  real(c_double):: abs_threshold=1d-13        ! Absolute convergence parameter for Newton-Raphson iterations.
+  real(c_double):: abs_threshold=1d-13       ! Absolute convergence parameter for Newton-Raphson iterations.
   real(c_double):: NewmarkDamp=1.d-4         ! Numerical damping in the Newmark integration scheme.
   logical(c_bool):: gravity_on = .FALSE.
   real(c_double):: gravity = 0.0d0

--- a/src/xbeam_solv.f90
+++ b/src/xbeam_solv.f90
@@ -1119,7 +1119,7 @@ subroutine xbeam_solv_couplednlndyn_step_updated(&
 
     ! Iteration loop -----------------------------------------
     converged = .FALSE.
-    abs_threshold = epsilon(residual)*1000
+    abs_threshold = options%abs_threshold
     do iter = 1, options%maxiterations + 1
         if (iter == options%maxiterations + 1) then
             print*, 'Solver did not converge in ', iter, ' iterations.'
@@ -1855,7 +1855,7 @@ subroutine xbeam_solv_coupledrigid_step(&
 
     ! Iteration loop -----------------------------------------
     converged = .FALSE.
-    abs_threshold = epsilon(residual)*1000
+    abs_threshold = options%abs_threshold
     do iter = 1, options%maxiterations + 1
         if (iter == options%maxiterations + 1) then
             print*, 'Solver did not converge in ', iter, ' iterations.'


### PR DESCRIPTION
The absolute threshold for the residual determined in the subroutine 'cbeam3_solv_nlndyn_step' was defined as too small to detect possible very small residuals that are not detected within convergence checks by the specified relative tolerance. The absolute threshold was added to xbopts with an increased default value to detect those very small residuals and solve the issue. In addition, the user can now specify the absolute threshold which was previously hard-coded in various subroutines within xbeam.
